### PR TITLE
feat: 음식 영양 정보 파싱 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,8 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
-	// com.sun.xml.bind
-	implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'
-	implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
-	// javax.xml.bind
-	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/healthbest/api/ApiApplication.java
+++ b/src/main/java/com/healthbest/api/ApiApplication.java
@@ -2,8 +2,10 @@ package com.healthbest.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 class ApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/healthbest/api/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/healthbest/api/auth/security/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.healthbest.api.auth.security.config;
 
-import com.healthbest.api.auth.jwt.JwtAuthenticationProvider;
 import com.healthbest.api.auth.jwt.JwtTokenExtractor;
 import com.healthbest.api.auth.jwt.JwtTokenValidator;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +27,9 @@ public class SecurityConfig {
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().requestMatchers("/api/v1/auth/**");
+        return (web) -> web.ignoring()
+                .requestMatchers("/api/v1/auth/**")
+                .requestMatchers("/api/v1/open-api/foods");
     }
 
     @Bean

--- a/src/main/java/com/healthbest/api/bloodSugar/repository/BloodSugarRepository.java
+++ b/src/main/java/com/healthbest/api/bloodSugar/repository/BloodSugarRepository.java
@@ -11,7 +11,9 @@ import java.util.List;
 
 public interface BloodSugarRepository extends JpaRepository<BloodSugar, Long> {
 
-    @Query("select b from BloodSugar b where b.user = :user and b.date between :startedTime and :endTime order by b.date")
+    @Query("select b from BloodSugar b " +
+            "where b.user = :user " +
+            "and b.date between :startedTime and :endTime order by b.date")
     List<BloodSugar> findBloodSugarByDate(
             @Param("user") User user,
             @Param("startedTime") LocalDateTime startedTime,

--- a/src/main/java/com/healthbest/api/common/domain/BaseTimeEntity.java
+++ b/src/main/java/com/healthbest/api/common/domain/BaseTimeEntity.java
@@ -1,12 +1,15 @@
 package com.healthbest.api.common.domain;
 
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
     @CreatedDate
     private LocalDateTime created;

--- a/src/main/java/com/healthbest/api/food/controller/FoodClient.java
+++ b/src/main/java/com/healthbest/api/food/controller/FoodClient.java
@@ -1,0 +1,39 @@
+package com.healthbest.api.food.controller;
+
+import com.healthbest.api.food.dto.FoodInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class FoodClient {
+
+    private final FoodProperties properties;
+
+    public FoodInfo request() {
+        String path = "/" + properties.getKey()
+                + "/" + properties.getServiceId()
+                + "/" + properties.getType()
+                + "/" + properties.getStartIdx()
+                + "/" + properties.getEndIdx();
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        FoodInfo response = webClient.get()
+                .uri(path)
+                .retrieve()
+                .bodyToMono(FoodInfo.class)
+                .block();
+
+        response.getRow().getInfos()
+                .forEach(info -> System.out.println(info.toString()));
+
+        return response;
+    }
+}

--- a/src/main/java/com/healthbest/api/food/controller/FoodController.java
+++ b/src/main/java/com/healthbest/api/food/controller/FoodController.java
@@ -1,0 +1,25 @@
+package com.healthbest.api.food.controller;
+
+import com.healthbest.api.food.dto.FoodInfo;
+import com.healthbest.api.food.service.FoodService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class FoodController {
+
+    private final FoodClient foodClient;
+    private final FoodService foodService;
+
+    @PostMapping("/open-api/foods")
+    public void parsing() {
+        FoodInfo foodInfo = foodClient.request();
+        foodService.create(foodInfo);
+    }
+}

--- a/src/main/java/com/healthbest/api/food/controller/FoodProperties.java
+++ b/src/main/java/com/healthbest/api/food/controller/FoodProperties.java
@@ -1,0 +1,22 @@
+package com.healthbest.api.food.controller;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class FoodProperties {
+    @Value("${open-api.service-id}")
+    private String serviceId;
+
+    @Value("${open-api.base-url}")
+    private String baseUrl;
+
+    @Value("${open-api.key}")
+    private String key;
+
+    private final String type = "json";
+    private final int startIdx = 1;
+    private final int endIdx = 10;   /* 인덱스 하나 당 음식 하나 */
+}

--- a/src/main/java/com/healthbest/api/food/domain/Food.java
+++ b/src/main/java/com/healthbest/api/food/domain/Food.java
@@ -1,0 +1,48 @@
+package com.healthbest.api.food.domain;
+
+import com.healthbest.api.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "food")
+public class Food extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private int amount;
+
+    private double calorie;
+
+    private double carbohydrate;
+
+    private double protein;
+
+    private double fat;
+
+    private double sugars;
+
+    private double sodium;
+
+    @Builder
+    public Food(
+            String name, int amount, double calorie, double carbohydrate,
+            double protein, double fat, double sugars, double sodium
+    ) {
+        this.name = name;
+        this.amount = amount;
+        this.calorie = calorie;
+        this.carbohydrate = carbohydrate;
+        this.protein = protein;
+        this.fat = fat;
+        this.sugars = sugars;
+        this.sodium = sodium;
+    }
+}

--- a/src/main/java/com/healthbest/api/food/dto/FoodInfo.java
+++ b/src/main/java/com/healthbest/api/food/dto/FoodInfo.java
@@ -1,0 +1,64 @@
+package com.healthbest.api.food.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FoodInfo {
+
+    @JsonProperty(value = "I2790")
+    private Row row;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Row {
+        @JsonProperty(value = "row")
+        private List<Info> infos;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Info {
+        @JsonProperty(value = "DESC_KOR")
+        private String name;
+
+        @JsonProperty(value = "SERVING_SIZE")
+        private String size;
+
+        @JsonProperty(value = "NUTR_CONT1")
+        private double calorie;
+
+        @JsonProperty(value = "NUTR_CONT2")
+        private double carbohydrate;
+
+        @JsonProperty(value = "NUTR_CONT3")
+        private double protein;
+
+        @JsonProperty(value = "NUTR_CONT4")
+        private double fat;
+
+        @JsonProperty(value = "NUTR_CONT5")
+        private double sugars;
+
+        @JsonProperty(value = "NUTR_CONT6")
+        private double sodium;
+
+        @Override
+        public String toString() {
+            return "FoodInfo{" +
+                    "name='" + name + '\'' +
+                    ", size='" + size + '\'' +
+                    ", calorie=" + calorie +
+                    ", carbohydrate=" + carbohydrate +
+                    ", protein=" + protein +
+                    ", fat=" + fat +
+                    ", sugars=" + sugars +
+                    ", sodium=" + sodium +
+                    '}';
+        }
+    }
+}

--- a/src/main/java/com/healthbest/api/food/repository/FoodRepository.java
+++ b/src/main/java/com/healthbest/api/food/repository/FoodRepository.java
@@ -1,0 +1,7 @@
+package com.healthbest.api.food.repository;
+
+import com.healthbest.api.food.domain.Food;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FoodRepository extends JpaRepository<Food, Long> {
+}

--- a/src/main/java/com/healthbest/api/food/service/FoodService.java
+++ b/src/main/java/com/healthbest/api/food/service/FoodService.java
@@ -1,0 +1,34 @@
+package com.healthbest.api.food.service;
+
+import com.healthbest.api.food.domain.Food;
+import com.healthbest.api.food.dto.FoodInfo;
+import com.healthbest.api.food.repository.FoodRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FoodService {
+    private final FoodRepository foodRepository;
+
+    @Transactional
+    public void create(FoodInfo foodInfo) {
+        foodInfo.getRow().getInfos().stream()
+                .map(this::generate)
+                .forEach(foodRepository::save);
+    }
+
+    private Food generate(FoodInfo.Info info) {
+        return Food.builder()
+                .name(info.getName())
+                .amount(Integer.parseInt(info.getSize()))
+                .calorie(info.getCalorie())
+                .carbohydrate(info.getCarbohydrate())
+                .protein(info.getProtein())
+                .fat(info.getFat())
+                .sugars(info.getSugars())
+                .sodium(info.getSodium())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,8 +8,13 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
 
 jwt:
   secret: testsetestsetsetsetsetst!!!
   expire-time: 9999999
+
+open-api:
+  base-url: ${OPEN_API_BASE_URL}
+  service-id: ${OPEN_API_SERVICE_ID}
+  key: ${OPEN_API_KEY}


### PR DESCRIPTION
## 작업 사항
* Issue: #4 
* WebClient 활용해 openAPI 요청
* 필요한 영양 정보만 파싱
* 파싱한 데이터 DB에 저장

## DDL
```sql
create table food (
    id bigint auto_increment,
    `name` varchar(50),
    amount int,
    calorie double(7, 2),
    carbohydrate double(7, 2),
    protein double(7, 2),
    fat double(7, 2),
    sugars double(7, 2),
    sodium double(7, 2),
    created timestamp,
    modified timestamp,
    primary key (id)
);
```